### PR TITLE
fix sticky bits and add inheritable option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
-        platform: [ubuntu-latest, macos-latest]
+        platform: [ubuntu-latest, macos-13] # intel mac only
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout

--- a/src/shinny_filelock/_flockd.py
+++ b/src/shinny_filelock/_flockd.py
@@ -4,21 +4,28 @@ from contextlib import contextmanager
 
 
 @contextmanager
-def flocked(path, blocking=True, create_file=False, shared=False):
+def flocked(path, blocking=True, create_file=False, shared=False, inheritable=False):
     """
     :param path: file path
     :param blocking: blocking lock, default True
     :param create_file: create file if not exists, default False
     :param shared: shared lock, default False
+    :param inheritable: inherit lock after exec, default False
     """
     fd = -1
+    fd_flags = os.O_RDONLY | os.O_NOCTTY
+    fd_flags_with_create = fd_flags | os.O_CREAT
     try:
-        fd_flags = os.O_RDONLY | os.O_NOCTTY
-        if create_file:
-            fd_flags |= os.O_CREAT
-        fd = os.open(path, fd_flags)
+        # when stick bits set, os.O_CREAT will raise PermissionError
+        try:
+            fd = os.open(path, fd_flags_with_create if create_file else fd_flags)
+        except PermissionError:
+            # maybe file exists and sits in a directory with sticky bits
+            fd = os.open(path, fd_flags)
         if fd == -1:
             raise ValueError()
+        # default fd in non-inheritable. See PEP 446: https://peps.python.org/pep-0446/
+        os.set_inheritable(fd, inheritable)
         flags = fcntl.LOCK_SH if shared else fcntl.LOCK_EX
         if not blocking:
             flags |= fcntl.LOCK_NB

--- a/tox.ini
+++ b/tox.ini
@@ -44,3 +44,4 @@ commands =
 [flake8]
 exclude = .tox,*.egg,build,data
 select = E,W,F
+max-line-length = 120


### PR DESCRIPTION
# 背景
`/run/lock` 目录是是属于root的带有 sticky bits 的 777 权限的目录
在 `/proc/sys/fs/protected_regular` 不为0的情况下，这个目录下只有root创建的文件可以被别的用户打开，任意非文件夹所有者创建的文件都不能被非文件所有者以外的人以 `O_CREAT` 打开

同时，python默认创建的fd强制注入了 O_CLOEXEC

# 方案
* 在 O_CREAT 打开失败后尝试去掉 O_CREAT 再次打开文件
* 在用户明确授意的情况下可以关闭 O_CLOEXEC flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新特性**
  - 引入了`inheritable`参数，允许锁在进程执行后被继承，提高了文件描述符在子进程中的控制能力。
- **错误修复**
  - 改进了打开文件的错误处理，增强了对`PermissionError`的处理。
- **测试**
  - 增强了测试套件，增加了新测试以验证不同用户权限下的锁定机制。
- **文档**
  - 更新了`flocked`函数的文档字符串，包含新的`inheritable`参数说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->